### PR TITLE
Exception when reading metadata from "HTML"

### DIFF
--- a/Classes/Resource/OnlineMedia/Helpers/YoukuHelper.php
+++ b/Classes/Resource/OnlineMedia/Helpers/YoukuHelper.php
@@ -114,6 +114,7 @@ class YoukuHelper extends AbstractOEmbedHelper
         );
 
         $doc = new \DOMDocument();
+        libxml_use_internal_errors(true);
         $doc->loadHTML($html);
 
         $title = 'Youku Video'; // Default value


### PR DESCRIPTION
Avoid exceptions like this

```
PHP Warning: DOMDocument::loadHTML(): Unexpected end tag : head in Entity
```

when adding a new file, by ignoring loadHTML warnings.